### PR TITLE
2.x validators scan string data from JSON uploads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ Changelog
 
 - Add Plone 4.3 compatability. [djowett-ftw]
 - Add a setting to disable virus scanning (Defaults to true). [djowett-ftw]
+- Use a previous scan result from the same request whether or not it passed
+  [djowett-ftw]
+- Add tests for AT validator [djowett-ftw]
+- Cache scan results using annotations on the request [djowett-ftw]
+- Add a 'scanStream' method to IValidator / ClamavValidator
+  and use it in validators (this saves memory doing scans) [djowett-ftw]
+- Copy new logic for archetypes validator to z3cform validator so tests pass
+  (not tested manually) [djowett-ftw]
 
 
 2.0a2 (2016-09-12)

--- a/src/collective/clamav/interfaces.py
+++ b/src/collective/clamav/interfaces.py
@@ -67,3 +67,6 @@ class IAVScanner(Interface):
 
     def scanBuffer(buffer):
         pass
+
+    def scanStream(buffer):
+        pass

--- a/src/collective/clamav/scanner.py
+++ b/src/collective/clamav/scanner.py
@@ -42,12 +42,17 @@ class ClamavScanner(object):
     def scanBuffer(self, buffer, type, **kwargs):
         """Scans a buffer for viruses
         """
+        return self.scanStream(BytesIO(buffer), type, **kwargs)
+
+    def scanStream(self, stream, type, **kwargs):
+        """Scans a stream for viruses
+        """
 
         timeout = kwargs.get('timeout', 120.0)
         kwargs_copy = dict(kwargs)
         kwargs_copy.update(timeout=timeout)
         cd = _make_clamd(type, **kwargs_copy)
-        status = cd.instream(BytesIO(buffer))
+        status = cd.instream(stream)
 
         if status["stream"][0] == "FOUND":
             return status["stream"][1]

--- a/src/collective/clamav/testing.py
+++ b/src/collective/clamav/testing.py
@@ -6,17 +6,16 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import PLONE_FIXTURE
-from plone.testing import z2
-
-import collective.clamav
-
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from plone.testing import z2
+from six import BytesIO
 from zope.component import getGlobalSiteManager
 from zope.configuration import xmlconfig
 from zope.interface import implements
 
 from collective.clamav.interfaces import IAVScanner
+import collective.clamav
 
 
 class CollectiveClamavLayer(PloneSandboxLayer):
@@ -73,12 +72,17 @@ class MockAVScanner(object):
         """
         return True
 
+    def scanStream(self, stream, type, **kwargs):
+        """
+        """
+        if EICAR in stream.read():
+            return 'Eicar-Test-Signature FOUND'
+        return None
+
     def scanBuffer(self, buffer, type, **kwargs):
         """
         """
-        if EICAR in buffer:
-            return 'Eicar-Test-Signature FOUND'
-        return None
+        return self.scanStream(BytesIO(buffer), type, **kwargs)
 
 
 class AVFixture(PloneSandboxLayer):

--- a/src/collective/clamav/validator.py
+++ b/src/collective/clamav/validator.py
@@ -56,9 +56,12 @@ class ClamavValidator:
             # when submitted a new 'file_value' is a
             # 'ZPublisher.HTTPRequest.FileUpload'
 
-            if getattr(value, '_validate_isVirusFree', False):
-                # validation is called multiple times for the same file upload
-                return True
+            prev_scan_result = getattr(value, '_validate_isVirusFree', None)
+            if prev_scan_result is not None:
+                # validation is called in mutator (setFile()) to *ensure*
+                # we never miss it, but the results are more user friendly if
+                # they are returned from validation code
+                return prev_scan_result
 
             file_value.seek(0)
             # TODO this reads the entire file into memory, there should be
@@ -73,6 +76,7 @@ class ClamavValidator:
                        "viruses: Please contact your system administrator."
 
             if result:
+                value._validate_isVirusFree = False
                 return "Validation failed, file is virus-infected. (%s)" % \
                        (result)
             else:

--- a/src/collective/clamav/validator.py
+++ b/src/collective/clamav/validator.py
@@ -6,6 +6,7 @@ from plone.registry.interfaces import IRegistry
 from six import BytesIO
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
+from zope.globalrequest import getRequest
 from zope.interface import implements, Invalid
 
 from collective.clamav.interfaces import IAVScanner
@@ -53,6 +54,10 @@ class ClamavValidator:
         # Get a previous scan result on this REQUEST if there is one - to
         # avoid scanning the same upload twice.
         request = kwargs['REQUEST']
+        if not request:
+            # Not very modern, but plone.restapi's DeserializeFromJson doesn't
+            # pass the request object to archetype validators
+            request = getRequest()
         annotations = IAnnotations(request)
         scan_result = annotations.get(SCAN_RESULT_KEY, None)
         if scan_result is not None:

--- a/src/collective/clamav/validator.py
+++ b/src/collective/clamav/validator.py
@@ -88,12 +88,12 @@ class ClamavValidator:
                    "viruses: Please contact your system administrator."
 
         if result:
-            annotations[SCAN_RESULT_KEY] = False
-            return "Validation failed, file is virus-infected. (%s)" % \
-                   (result)
+            annotations[SCAN_RESULT_KEY] = (
+                "Validation failed, file is virus-infected. (%s)" % result
+            )
         else:
             annotations[SCAN_RESULT_KEY] = True
-            return True
+        return annotations[SCAN_RESULT_KEY]
 
 
 try:
@@ -144,10 +144,10 @@ else:
                               "contact your system administrator.")
 
             if result:
-                annotations[SCAN_RESULT_KEY] = False
-                raise Invalid("Validation failed, file "
-                              "is virus-infected. (%s)" %
-                              (result))
+                annotations[SCAN_RESULT_KEY] = (
+                    "Validation failed, file is virus-infected. (%s)" % result
+                )
+                raise Invalid(annotations[SCAN_RESULT_KEY])
             else:
                 annotations[SCAN_RESULT_KEY] = True
                 return True

--- a/src/collective/clamav/validator.py
+++ b/src/collective/clamav/validator.py
@@ -39,7 +39,7 @@ def scanStream(stream):
 
 
 def _scanBuffer(buffer):
-    scanStream(BytesIO(buffer))
+    return scanStream(BytesIO(buffer))
 
 
 class ClamavValidator:


### PR DESCRIPTION
Also enabled switched the validator to scan streams rather than string buffers to save memory and we already had filelike objects available.
We now cache the scan results on the request rather than on the FileUpload object (as we might not have one)

Still to do:
- extra test
- logging

https://4teamwork.atlassian.net/browse/OGB-399